### PR TITLE
Fix panel name mapping in daily message report

### DIFF
--- a/ayer
+++ b/ayer
@@ -158,14 +158,14 @@ function crearEncabezadosMensajesAyer(hoja, fechaAyer) {
 
 function llenarDatosMensajesAyer(hoja, reportePaneles) {
     const filaInicio = 5;
-    
+
     // Obtener mapeo de números a nombres
     const mapeoNumeroANombre = obtenerMapeoDesdeHojaPaneles();
     console.log('🗂️ Mapeo obtenido para llenar datos:', mapeoNumeroANombre);
 
     reportePaneles.forEach((panelData, index) => {
         const fila = filaInicio + index;
-        
+
         // Usar los datos correctos del JSON estructurado
         const mensajes = panelData.total_mensajes_hoy || 0;
         const cargas = panelData.cargas_hoy || 0;
@@ -176,11 +176,29 @@ function llenarDatosMensajesAyer(hoja, reportePaneles) {
             hoja.getRange(fila, 1, 1, 4).setBackground("#f9fbe7");
         }
 
-        // Convertir número de panel a nombre usando el mapeo dinámico
-        const numeroPanel = String(panelData.panel || "");
-        const nombrePanel = mapeoNumeroANombre[numeroPanel] || numeroPanel;
+        // Obtener el código del panel desde los datos (normalizado)
+        const codigoPanel = normalizarCodigoPanel(
+            panelData.panel ??
+            panelData.codigo ??
+            panelData.numero ??
+            panelData.id
+        );
 
-        console.log(`📋 Panel ${index + 1}: Número "${numeroPanel}" → Nombre "${nombrePanel}"`);
+        // Intentar obtener un nombre ya presente en la respuesta
+        const nombreDesdeDatos = obtenerNombrePanelDesdeDatos(panelData);
+
+        // Buscar el nombre en el mapeo dinámico si no vino en los datos
+        let nombrePanel = nombreDesdeDatos;
+        if (!nombrePanel && codigoPanel) {
+            nombrePanel = mapeoNumeroANombre[codigoPanel] || "";
+        }
+
+        // Si aún no se encuentra, usar el código como último recurso
+        if (!nombrePanel) {
+            nombrePanel = codigoPanel || "sin panel";
+        }
+
+        console.log(`📋 Panel ${index + 1}: Código "${codigoPanel}" → Nombre "${nombrePanel}"`);
 
         // Llenar las columnas con los datos correctos
         hoja.getRange(fila, 1).setValue(nombrePanel);
@@ -219,6 +237,35 @@ function imprimirFrasesCierreEnColumnaC(hoja, respuestasPaneles) {
     Logger.log("✅ Datos de cargas y porcentajes ya incluidos en reportePaneles");
 }
 
+function obtenerNombrePanelDesdeDatos(panelData) {
+    if (!panelData || typeof panelData !== 'object') {
+        return "";
+    }
+
+    const posiblesNombres = [
+        panelData.nombre_panel,
+        panelData.panel_nombre,
+        panelData.nombrePanel,
+        panelData.nombre,
+        panelData.panelName
+    ];
+
+    for (let nombre of posiblesNombres) {
+        if (nombre === null || nombre === undefined) continue;
+
+        try {
+            const texto = String(nombre).trim();
+            if (texto) {
+                return texto.toLowerCase();
+            }
+        } catch (error) {
+            console.log('⚠️ No se pudo convertir nombre de panel a texto:', nombre, error);
+        }
+    }
+
+    return "";
+}
+
 function agregarGastosPorPanelDesdeCampanias(hoja, campaniasMetaAds) {
     // ✅ VALIDACIÓN: Verificar que campaniasMetaAds existe
     if (!campaniasMetaAds) {
@@ -235,7 +282,8 @@ function agregarGastosPorPanelDesdeCampanias(hoja, campaniasMetaAds) {
     const mapeoNombreANumero = {};
     for (let numero in mapeoNumeroANombre) {
         const nombre = mapeoNumeroANombre[numero];
-        mapeoNombreANumero[nombre] = numero;
+        if (!nombre) continue;
+        mapeoNombreANumero[String(nombre).toLowerCase()] = numero;
     }
     console.log('🔄 Mapeo nombre → número:', mapeoNombreANumero);
     
@@ -303,7 +351,10 @@ function agregarGastosPorPanelDesdeCampanias(hoja, campaniasMetaAds) {
         const panelString = String(fila[0] ?? '').trim();
 
         // ✅ CORRECCIÓN: Usar mapeo dinámico para obtener el número
-        const numeroPanel = mapeoNombreANumero[panelString.toLowerCase()] || panelString;
+        const numeroPanel =
+            mapeoNombreANumero[panelString.toLowerCase()] ||
+            normalizarCodigoPanel(panelString) ||
+            panelString;
 
         console.log(`🔄 Panel fila ${index + 1}: "${panelString}" → Número para gastos: "${numeroPanel}"`);
 
@@ -468,18 +519,18 @@ function obtenerMapeoDesdeHojaPaneles() {
         for (let i = 0; i < nombresPanel.length; i++) {
             const nombre = nombresPanel[i][0];
             const codigo = codigosPanel[i][0];
-            
+
             if (nombre && codigo) {
                 const nombreStr = String(nombre).trim().toLowerCase();
-                const codigoStr = String(codigo).trim();
-                
+                const codigoStr = normalizarCodigoPanel(codigo);
+
                 if (nombreStr && codigoStr) {
                     mapeoNumeroANombre[codigoStr] = nombreStr;
                     console.log(`📌 Mapeo agregado: ${codigoStr} → ${nombreStr}`);
                 }
             }
         }
-        
+
         console.log('✅ Mapeo desde hoja PANELES completado:', mapeoNumeroANombre);
         return mapeoNumeroANombre;
         
@@ -487,6 +538,36 @@ function obtenerMapeoDesdeHojaPaneles() {
         console.error('❌ Error al leer hoja PANELES:', error);
         return {};
     }
+}
+
+function normalizarCodigoPanel(codigo) {
+    if (codigo === null || codigo === undefined) {
+        return "";
+    }
+
+    let codigoStr;
+
+    try {
+        codigoStr = String(codigo).trim();
+    } catch (error) {
+        console.log('⚠️ No se pudo convertir código de panel a texto:', codigo, error);
+        return "";
+    }
+
+    if (!codigoStr) {
+        return "";
+    }
+
+    if (/^\d+$/.test(codigoStr)) {
+        return String(parseInt(codigoStr, 10));
+    }
+
+    const match = codigoStr.match(/(\d+)/);
+    if (match) {
+        return String(parseInt(match[1], 10));
+    }
+
+    return codigoStr.toLowerCase();
 }
 
 function obtenerMapeoNombresDesdeHojaExterna() {


### PR DESCRIPTION
## Summary
- normalize panel codes before matching them to the dynamic mapping
- derive panel names directly from the API data when available and fall back to the mapping
- share normalization helpers so spending columns continue to match the correct panels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e446ad0e248321bb061315fb442ca9